### PR TITLE
Update README.md to include issue for Nest.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Console Ninja currently supports the following tools:
   - [Gatsby.js](https://www.gatsbyjs.com/);
   - any web applications configured to use Webpack node module.
 - [Next.js](https://nextjs.org/), including first class support for browser and server side (Node and Edge) logs.
-- [Nest.js](https://nestjs.com).
+- [Nest.js](https://nestjs.com), if using Nest.js 10+ with [SWC](https://swc.rs/) as compiler, follow instructions of [this comment](https://github.com/wallabyjs/console-ninja/issues/220#issuecomment-1774408715).
 - [Remix](https://remix.run/), including first class support for client and server side logs (no errors).
 - [Nuxt](https://nuxt.com).
 - [Astro](https://astro.build), including first class support for client and server side logs (no server side errors).


### PR DESCRIPTION
Clarification of usage in Nest.js 10+ with SWC as a new compiler.